### PR TITLE
fix(Tailwind): use js config for tailwind

### DIFF
--- a/codux.config.json
+++ b/codux.config.json
@@ -21,6 +21,5 @@
     }
   },
   "styling": { "solution": "css" },
-  "tailwindcssConfig": "./tailwind.config.cjs",
   "svgLoader": "both"
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
fixes: https://github.com/wixplosives/codux/issues/17269
In this example of a tailwind project we use Tailwind config with cjs but the Tailwind documentation uses js so when users paste js config code from the tailwind docs, it doesn't work.